### PR TITLE
3 d rule add

### DIFF
--- a/Editor/TileMap3D_Editor.cs
+++ b/Editor/TileMap3D_Editor.cs
@@ -21,8 +21,8 @@ public class TileMap3D_Editor : Editor
     void CreateMap(TileMap3D tilemap)
     {
         CalculateYValues(tilemap);
-        isFilled = new bool[tilemap.heightMap.width, tilemap.numberOfFloors, tilemap.heightMap.height];
-        tileInstatiated = new bool[tilemap.heightMap.width, tilemap.numberOfFloors, tilemap.heightMap.height];
+        isFilled = new bool[tilemap.heightMap.width, tilemap.numberOfFloors +1, tilemap.heightMap.height];
+        tileInstatiated = new bool[tilemap.heightMap.width, tilemap.numberOfFloors +1, tilemap.heightMap.height];
         for (int i = 0; i < tilemap.heightMap.width; i++)
         {
             for (int j = 0; j < tilemap.numberOfFloors; j++)
@@ -39,27 +39,31 @@ public class TileMap3D_Editor : Editor
             }
         }
 
-        FillWithObject(TileMap3DRule.RuleType.UpperCornerLeft, tilemap, tilemap.tileCornerUpperLeft);
-        FillWithObject(TileMap3DRule.RuleType.UpperSideTop, tilemap, tilemap.tileSideUp);
-        FillWithObject(TileMap3DRule.RuleType.Fill, tilemap, tilemap.tileFill);
+        GameObject map = new GameObject("map");
+        map.transform.parent = tilemap.transform;
+        GameObject[] tiles = { tilemap.tileMiddleCorner, tilemap.tileMiddleFill, tilemap.tileCornerUpperLeft, tilemap.tileSideUp, tilemap.tileFill };
+        for(int i=0; i< tiles.Length; i++)
+        {
+            if(tiles[i] !=null)
+                FillWithObject((TileMap3DRule.RuleType)i, tilemap, tiles[i], map);
+        }
         
-
     }
 
-    void FillWithObject(TileMap3DRule.RuleType type, TileMap3D tilemap, GameObject obj)
+    void FillWithObject(TileMap3DRule.RuleType type, TileMap3D tilemap, GameObject obj, GameObject parent)
     {
 
         TileMap3DRule r = new TileMap3DRule(type);
-        FillWithObject(r, tilemap, obj);
+        FillWithObject(r, tilemap, obj, parent);
     }
 
-    void FillWithObject(TileMap3DRule rule, TileMap3D tilemap, GameObject obj)
+    void FillWithObject(TileMap3DRule rule, TileMap3D tilemap, GameObject obj, GameObject parent)
     {
         Quaternion rot = Quaternion.identity;
         Vector3 eulers = new Vector3(0, 0, 0);
         for (int i = 0; i < 4; i++)
         {
-            CheckRuleAndInstatiate(rule, tilemap, obj, rot);
+            CheckRuleAndInstatiate(rule, tilemap, obj, rot, parent);
             rule.Rotate90();
             eulers += new Vector3(0, 90, 0);
             rot = Quaternion.Euler(eulers);
@@ -81,7 +85,7 @@ public class TileMap3D_Editor : Editor
         return true;
     }
 
-    void CheckRuleAndInstatiate(TileMap3DRule rule, TileMap3D tilemap, GameObject obj, Quaternion rotation)
+    void CheckRuleAndInstatiate(TileMap3DRule rule, TileMap3D tilemap, GameObject obj, Quaternion rotation,GameObject parent)
     {
         for(int i =0; i< tilemap.heightMap.width; i++)
         {
@@ -93,6 +97,7 @@ public class TileMap3D_Editor : Editor
                     {
                         GameObject aux = GameObject.Instantiate(obj, new Vector3(i * tilemap.tileX, k * tilemap.tileHeight, j * tilemap.tileZ), obj.transform.rotation);
                         aux.transform.rotation = rotation * aux.transform.rotation;
+                        aux.transform.parent = parent.transform; 
                         tileInstatiated[i, k, j] = true;
                     }
                 }

--- a/TileMap3D.cs
+++ b/TileMap3D.cs
@@ -17,6 +17,12 @@ public class TileMap3D : MonoBehaviour
     public GameObject tileFill;
 
     [SerializeField]
+    public GameObject tileMiddleFill;
+
+    [SerializeField]
+    public GameObject tileMiddleCorner;
+
+    [SerializeField]
     public float tileX;
 
     [SerializeField]
@@ -28,25 +34,4 @@ public class TileMap3D : MonoBehaviour
     [SerializeField]
     public int numberOfFloors;
     
-
-    /*void Start()
-    {
-        int width = heightMap.width;
-        int height = heightMap.height;
-        for(int i=0; i< heightMap.width; i++)
-        {
-            for(int j=0; j<heightMap.height; j++)
-            {
-                float c = heightMap.GetPixel(i, j).r;
-                Debug.Log(c);
-                GameObject ob = GameObject.Instantiate(tileFill, new Vector3(i * tileX, tileHeight * GetFloor(c), j * tileY), Quaternion.identity);
-            }
-        }
-    }*/
-
-
-
-
-
-
 }

--- a/TileMap3DRule.cs
+++ b/TileMap3DRule.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TileMap3DRule
+{
+    public Dictionary<Vector3Int, int> rule;
+    
+    public  TileMap3DRule()
+    {
+        rule = new Dictionary<Vector3Int, int>();
+    }
+
+    public TileMap3DRule(RuleType type)
+    {
+        rule = new Dictionary<Vector3Int, int>();
+        if (type == RuleType.UpperSideTop)
+        {
+            rule.Add(new Vector3Int(-1, 0, 0), 1);
+            rule.Add(new Vector3Int(1, 0, 0), 1);
+            rule.Add(new Vector3Int(0, 0, 1), -1);
+            rule.Add(new Vector3Int(0, 0, -1), 1);
+            
+        }
+        if(type == RuleType.UpperCornerLeft)
+        {
+            rule.Add(new Vector3Int(1, 0, 0), 1);
+            rule.Add(new Vector3Int(0, 0, -1), 1);
+            rule.Add(new Vector3Int(-1, 0, 1), -1);
+            rule.Add(new Vector3Int(0, 0, 1), -1);
+            rule.Add(new Vector3Int(-1, 0, 0), -1);
+        }
+    }
+
+    public void Rotate90()
+    {
+        Dictionary<Vector3Int, int> rotatedRule = new Dictionary<Vector3Int, int>();
+        foreach(KeyValuePair<Vector3Int, int> c in rule)
+        {
+            rotatedRule.Add(new Vector3Int(c.Key.z, c.Key.y, -c.Key.x), c.Value);
+        }
+        rule = rotatedRule;
+    }
+
+    public enum RuleType
+    {
+        UpperCornerLeft = 0,
+        UpperSideTop= 1,
+        Fill = 2
+    }
+}

--- a/TileMap3DRule.cs
+++ b/TileMap3DRule.cs
@@ -14,7 +14,7 @@ public class TileMap3DRule
     public TileMap3DRule(RuleType type)
     {
         rule = new Dictionary<Vector3Int, int>();
-        if (type == RuleType.UpperSideTop)
+        if (type == RuleType.TopSideUp)
         {
             rule.Add(new Vector3Int(-1, 0, 0), 1);
             rule.Add(new Vector3Int(1, 0, 0), 1);
@@ -22,7 +22,7 @@ public class TileMap3DRule
             rule.Add(new Vector3Int(0, 0, -1), 1);
             
         }
-        if(type == RuleType.UpperCornerLeft)
+        if(type == RuleType.TopCornerUpLeft)
         {
             rule.Add(new Vector3Int(1, 0, 0), 1);
             rule.Add(new Vector3Int(0, 0, -1), 1);
@@ -30,6 +30,30 @@ public class TileMap3DRule
             rule.Add(new Vector3Int(0, 0, 1), -1);
             rule.Add(new Vector3Int(-1, 0, 0), -1);
         }
+        if(type == RuleType.MiddleCornerUpLeft)
+        {
+            rule.Add(new Vector3Int(1, 0, 0), 1);
+            rule.Add(new Vector3Int(0, 0, -1), 1);
+            rule.Add(new Vector3Int(-1, 0, 1), -1);
+            rule.Add(new Vector3Int(0, 0, 1), -1);
+            rule.Add(new Vector3Int(-1, 0, 0), -1);
+            rule.Add(new Vector3Int(0, 1, 0), 1);
+            rule.Add(new Vector3Int(1, 1, 0), 1);
+            rule.Add(new Vector3Int(0, 1, -1), 1);
+        }
+        if(type == RuleType.MiddleSideUp)
+        {
+            rule.Add(new Vector3Int(-1, 0, 0), 1);
+            rule.Add(new Vector3Int(1, 0, 0), 1);
+            rule.Add(new Vector3Int(0, 0, 1), -1);
+            rule.Add(new Vector3Int(0, 0, -1), 1);
+            rule.Add(new Vector3Int(-1, 1, 0), 1);
+            rule.Add(new Vector3Int(1, 1, 0), 1);
+            rule.Add(new Vector3Int(0, 1, 1), -1);
+            rule.Add(new Vector3Int(0, 1, -1), 1);
+            rule.Add(new Vector3Int(0, 1, 0), 1);
+        }
+        
     }
 
     public void Rotate90()
@@ -44,8 +68,10 @@ public class TileMap3DRule
 
     public enum RuleType
     {
-        UpperCornerLeft = 0,
-        UpperSideTop= 1,
-        Fill = 2
+        TopCornerUpLeft = 2,
+        TopSideUp= 3,
+        Fill = 4,
+        MiddleCornerUpLeft =0,
+        MiddleSideUp = 1
     }
 }

--- a/TileMap3DRule.cs.meta
+++ b/TileMap3DRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0354f432485ae1e4eb7351b97a58c936
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Code was rewrote, instead of cases each tile has a 3dRule.
Added TileMap3DRule class.
Fixed bug where tiles had a wrong rotation in the map.
Code is less repetitive now.
Map instatiates just the tiles that has been set up. Tiles that has not been set up doesn't cause an error anymore.
